### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EXAMPLE
 ```hcl
 module "dcos-master-instance" {
   source  = "terraform-dcos/instance/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   cluster_name = "production"
   subnet_ids = ["subnet-12345678"]

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@
  *```hcl
  * module "dcos-master-instance" {
  *   source  = "terraform-dcos/instance/aws"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   cluster_name = "production"
  *   subnet_ids = ["subnet-12345678"]
@@ -32,7 +32,7 @@ provider "aws" {}
 
 module "dcos-tested-oses" {
   source  = "dcos-terraform/tested-oses/aws"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   providers = {
     aws = "aws"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2