### PR TITLE
breaking change: allow prereqs for instance termination/redeployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,11 @@ resource "aws_instance" "instance" {
 }
 
 resource "null_resource" "instance-prereq" {
+  # Changes to any instance of the cluster requires re-provisioning
+  triggers {
+    current_ec2_instance_id = "${element(aws_instance.instance.*.id, count.index)}"
+  }
+
   // if the user supplies an AMI or user_data we expect the prerequisites are met.
   count = "${coalesce(var.ami, var.user_data) == "" ? var.num : 0}"
 

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_instance" "instance" {
 resource "null_resource" "instance-prereq" {
   # Changes to any instance of the cluster requires re-provisioning
   triggers {
-    current_ec2_instance_id = "${element(aws_instance.instance.*.id, count.index)}"
+    current_instance_id = "${element(aws_instance.instance.*.id, count.index)}"
   }
 
   // if the user supplies an AMI or user_data we expect the prerequisites are met.


### PR DESCRIPTION
When instances are terminated from an external source, this change allows the prereqs to be rerun