### PR TITLE
lifecycle ignore changes to volumes and attachments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,10 @@ resource "aws_ebs_volume" "volume" {
                                var.cluster_name,
                                element(aws_instance.instance.*.id, count.index / local.num_extra_volumes)),
                 "Cluster", var.cluster_name))}"
+
+  lifecycle {
+    ignore_changes = ["instance_id"]
+  }
 }
 
 resource "aws_volume_attachment" "volume-attachment" {
@@ -132,4 +136,8 @@ resource "aws_volume_attachment" "volume-attachment" {
   volume_id    = "${element(aws_ebs_volume.volume.*.id, count.index)}"
   instance_id  = "${element(aws_instance.instance.*.id, count.index / local.num_extra_volumes)}"
   force_detach = true
+
+  lifecycle {
+    ignore_changes = ["instance_id", "vol_id"]
+  }
 }


### PR DESCRIPTION
Adding lifecycle ignore changes to volumes and volume attachment resources to address dcos-terraform-aws issue 71 https://github.com/dcos-terraform/terraform-aws-dcos/issues/71. 

When scaling private agents with additional volumes, Terraform attempts to destroy and recreate all volumes.

Below is example of going from 3 to 4:
```
-/+ module.volumeagent.module.dcos-private-agent-instances.aws_ebs_volume.volume[0] (new resource required)
      id:                                         "vol-042005c2231204963" => <computed> (forces new resource)
      arn:                                        "arn:aws:ec2:us-west-2:008562636938:volume/vol-042005c2231204963" => <computed>
      availability_zone:                          "us-west-2a" => "${element(aws_instance.instance.*.availability_zone, count.index / local.num_extra_volumes)}" (forces new resource)
      encrypted:                                  "false" => <computed>
      kms_key_id:                                 "" => <computed>
      size:                                       "1000" => "1000"
      snapshot_id:                                "" => <computed>
      tags.%:                                     "2" => <computed>
      tags.Cluster:                               "gc3" => ""
      tags.Name:                                  "extra-volumes-gc3-i-05f3b4cb4c3b5510a" => ""
      type:                                       "gp2" => "gp2"

-/+ module.volumeagent.module.dcos-private-agent-instances.aws_ebs_volume.volume[1] (new resource required)
      id:                                         "vol-0a24397644298bc52" => <computed> (forces new resource)
      arn:                                        "arn:aws:ec2:us-west-2:008562636938:volume/vol-0a24397644298bc52" => <computed>
      availability_zone:                          "us-west-2b" => "${element(aws_instance.instance.*.availability_zone, count.index / local.num_extra_volumes)}" (forces new resource)
      encrypted:                                  "false" => <computed>
      kms_key_id:                                 "" => <computed>
      size:                                       "1000" => "1000"
      snapshot_id:                                "" => <computed>
      tags.%:                                     "2" => <computed>
      tags.Cluster:                               "gc3" => ""
      tags.Name:                                  "extra-volumes-gc3-i-0f2372b7ea8b765ce" => ""
      type:                                       "gp2" => "gp2"

-/+ module.volumeagent.module.dcos-private-agent-instances.aws_ebs_volume.volume[2] (new resource required)
      id:                                         "vol-0d2fc2e402cc9f5ce" => <computed> (forces new resource)
      arn:                                        "arn:aws:ec2:us-west-2:008562636938:volume/vol-0d2fc2e402cc9f5ce" => <computed>
      availability_zone:                          "us-west-2d" => "${element(aws_instance.instance.*.availability_zone, count.index / local.num_extra_volumes)}" (forces new resource)
      encrypted:                                  "false" => <computed>
      kms_key_id:                                 "" => <computed>
      size:                                       "1000" => "1000"
      snapshot_id:                                "" => <computed>
      tags.%:                                     "2" => <computed>
      tags.Cluster:                               "gc3" => ""
      tags.Name:                                  "extra-volumes-gc3-i-0469ef739adcc269e" => ""
      type:                                       "gp2" => "gp2"

  + module.volumeagent.module.dcos-private-agent-instances.aws_ebs_volume.volume[3]
      id:                                         <computed>
      arn:                                        <computed>
      availability_zone:                          "${element(aws_instance.instance.*.availability_zone, count.index / local.num_extra_volumes)}"
      encrypted:                                  <computed>
      kms_key_id:                                 <computed>
      size:                                       "1000"
      snapshot_id:                                <computed>
      tags.%:                                     <computed>
      type:                                       "gp2"
```

By using lifecycle and ignore changes to instance ids and volume ids, it allows:
- the current volumes and attachments to remain unmodified
- if a volume gets detached, TF will attach it back to the correct instance
- if a volume gets destroyed with a specific instance, the volume is recreated and reattached to the instance where the volume was destroyed. 